### PR TITLE
Fix MCP server working directory handling for Claude Desktop MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,23 @@ claude mcp add claudepoint claudepoint
 #### For Claude Desktop (GUI Application):
 Add to your Claude Desktop configuration file:
 
-**macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+**macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json
+### Advanced Configuration: Project-Specific Directories
+
+To use ClaudePoint with a specific project directory in Claude Desktop, you can set the `CLAUDEPOINT_PROJECT_DIR` environment variable:
+
+```json
+{
+  "mcpServers": {
+    "claudepoint": {
+      "command": "claudepoint",
+      "args": [],
+      "env": {
+        "CLAUDEPOINT_PROJECT_DIR": "/path/to/your/project"
+      }
+    }
+  }
+}`
 **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
 
 ```json

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -29,7 +29,13 @@ class ClaudePointMCPServer {
       }
     );
 
-    this.manager = new CheckpointManager();
+    // Use environment variable, home directory, or current directory (in that order)
+    const workingDir = process.env.CLAUDEPOINT_PROJECT_DIR || 
+                    process.env.HOME || 
+                    process.cwd();
+    console.error(`[claudepoint] Using working directory: ${workingDir}`);
+    this.manager = new CheckpointManager(workingDir);
+    
     this.setupToolHandlers();
   }
 


### PR DESCRIPTION
## Problem
When using ClaudePoint as an MCP server in Claude Desktop, it attempts to use `/` as the working directory, causing errors like:

❌ Setup failed: ENOENT: no such file or directory, mkdir '/.checkpoints'


## Solution
This PR adds support for specifying the working directory through environment variables:
1. First checks `CLAUDEPOINT_PROJECT_DIR` environment variable
2. Falls back to `HOME` directory if not set
3. Uses `process.cwd()` as last resort
4. Adds logging to show which directory is being used

## Configuration
Users can now configure Claude Desktop to use ClaudePoint with a specific project:

```json
{
  "mcpServers": {
    "claudepoint": {
      "command": "claudepoint",
      "args": [],
      "env": {
        "CLAUDEPOINT_PROJECT_DIR": "/path/to/project"
      }
    }
  }
}