### PR TITLE
Fix ERR_REQUIRE_ESM error by using dynamic imports

### DIFF
--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -7,13 +7,21 @@
  * GitHub: https://github.com/Andycufari/ClaudePoint
  */
 
-const { Server } = require('@modelcontextprotocol/sdk/server/index.js');
-const { StdioServerTransport } = require('@modelcontextprotocol/sdk/server/stdio.js');
-const { 
-  CallToolRequestSchema, 
-  ListToolsRequestSchema 
-} = require('@modelcontextprotocol/sdk/types.js');
+// Use dynamic imports for ES modules
+let Server, StdioServerTransport, CallToolRequestSchema, ListToolsRequestSchema;
 const CheckpointManager = require('./lib/checkpoint-manager.js');
+
+// Initialize ES module imports
+async function loadESModules() {
+  const serverModule = await import('@modelcontextprotocol/sdk/server/index.js');
+  const stdioModule = await import('@modelcontextprotocol/sdk/server/stdio.js');
+  const typesModule = await import('@modelcontextprotocol/sdk/types.js');
+  
+  Server = serverModule.Server;
+  StdioServerTransport = stdioModule.StdioServerTransport;
+  CallToolRequestSchema = typesModule.CallToolRequestSchema;
+  ListToolsRequestSchema = typesModule.ListToolsRequestSchema;
+}
 
 class ClaudePointMCPServer {
   constructor() {
@@ -487,11 +495,18 @@ class ClaudePointMCPServer {
   }
 }
 
-// Start the server
-const server = new ClaudePointMCPServer();
-server.start().catch(error => {
-  console.error('Failed to start server:', error);
-  process.exit(1);
-});
+// Start the server with async initialization
+async function main() {
+  try {
+    await loadESModules();
+    const server = new ClaudePointMCPServer();
+    await server.start();
+  } catch (error) {
+    console.error('Failed to start server:', error);
+    process.exit(1);
+  }
+}
+
+main();
 
 module.exports = ClaudePointMCPServer;


### PR DESCRIPTION
## Problem
  The MCP server fails to start with Claude Code due to CommonJS/ES module incompatibility:
  Error [ERR_REQUIRE_ESM]: require() of ES Module @modelcontextprotocol/sdk/server/index.js not supported

  ## Solution
  - Converted `require()` calls to dynamic `import()` for @modelcontextprotocol/sdk modules
  - Wrapped server initialization in async function to handle promises
  - Maintained backward compatibility with CommonJS CheckpointManager

  ## Testing
  - Tested locally with Node.js v20.11.1
  - MCP server now starts successfully
  - All tools remain functional

  ## Impact
  This fixes the MCP integration for all Claude Code users, making checkpoint tools available through the Claude
  interface.