### PR TITLE
feat: add Claude Code slash commands support (#4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ Claude will automatically use ClaudePoint tools!
 
 Once configured, you can naturally tell Claude:
 
+### **Using Slash Commands (Fastest!):**
+```
+/create-checkpoint working-auth Everything works perfectly here
+/list-checkpoints
+/restore-checkpoint
+/checkpoint-status
+```
+
 ### **Project Setup:**
 ```
 "Setup checkpoints for this project and show me what we've worked on before"
@@ -130,7 +138,41 @@ claudepoint log "Fixed authentication bug" --details "Resolved OAuth token expir
 # Restore checkpoint
 claudepoint restore "before-major" --dry-run
 claudepoint restore "before-major"
+
+# Initialize slash commands for Claude Code
+claudepoint init-commands
 ```
+
+## 🚀 Slash Commands (NEW!)
+
+ClaudePoint now supports Claude Code slash commands for faster operations! These commands appear in Claude Code when you type `/`.
+
+### Setup Slash Commands
+
+```bash
+# During initial setup
+claudepoint setup
+
+# Or add to existing project
+claudepoint init-commands
+```
+
+### Available Slash Commands
+
+- **`/create-checkpoint`** - Create a checkpoint with optional name and description
+  - Example: `/create-checkpoint auth-working Authentication system complete`
+  
+- **`/restore-checkpoint`** - Interactive checkpoint restoration
+  - Shows numbered list of checkpoints
+  - Waits for your selection (by number or name)
+  
+- **`/list-checkpoints`** - Quick view of all checkpoints
+  
+- **`/checkpoint-status`** - Current status and recent activity
+
+### How It Works
+
+The slash commands are simple markdown files in `.claude/commands/` that guide Claude to use the appropriate ClaudePoint MCP tools. You can customize them after generation to fit your workflow!
 
 ## 🛠️ MCP Tools (For Claude)
 
@@ -142,6 +184,7 @@ When Claude has ClaudePoint configured, it can use:
 - **`restore_checkpoint`** - Restore previous state (with emergency backup)
 - **`get_changelog`** - View development history and session activities
 - **`set_changelog`** - Add custom entries to development history
+- **`init_slash_commands`** - Initialize Claude Code slash commands for the project
 
 ## 📋 Development History & Session Continuity
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claudepoint",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "The safest way to experiment with Claude Code. Create instant checkpoints, experiment fearlessly, restore instantly.",
   "main": "bin/claudepoint.js",
   "bin": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -8,11 +8,12 @@ const CheckpointManager = require('./lib/checkpoint-manager');
 const chalk = require('chalk');
 const ora = require('ora');
 const inquirer = require('inquirer');
+const { initializeSlashCommands } = require('./lib/slash-commands');
 
 program
   .name('claudepoint')
   .description('The safest way to experiment with Claude Code')
-  .version('1.1.1');
+  .version('1.1.2');
 
 program
   .command('setup')
@@ -33,7 +34,22 @@ program
         if (result.initialCheckpoint) {
           console.log(chalk.green(`✅ Created initial checkpoint: ${result.initialCheckpoint}`));
         }
+
+        spinner.start('Creating Claude Code slash commands...');
+        await initializeSlashCommands();
+        spinner.succeed('Slash commands created!');
+        console.log(chalk.green('✅ Created .claude/commands directory'));
+        console.log(chalk.green('✅ Added /create-checkpoint command'));
+        console.log(chalk.green('✅ Added /restore-checkpoint command'));
+        console.log(chalk.green('✅ Added /list-checkpoints command'));
+        console.log(chalk.green('✅ Added /checkpoint-status command'));
         
+        console.log(chalk.blue('\n🚀 Claude Code slash commands:'));
+        console.log('  /create-checkpoint - Create a new checkpoint');
+        console.log('  /restore-checkpoint - Restore with interactive selection');
+        console.log('  /list-checkpoints - List all checkpoints');
+        console.log('  /checkpoint-status - Show current status');
+
         console.log(chalk.blue('\n📋 Quick commands:'));
         console.log('  claudepoint create --description "Your description"');
         console.log('  claudepoint list');
@@ -215,6 +231,35 @@ program
       console.log(chalk.green(`✅ Changelog entry added: ${description}`));
     } catch (error) {
       console.error(chalk.red('❌ Log failed:'), error.message);
+      process.exit(1);
+    }
+  });
+
+program
+  .command('init-commands')
+  .description('Initialize Claude Code slash commands for ClaudePoint')
+  .action(async () => {
+    const spinner = ora('Creating Claude Code slash commands...').start();
+    
+    try {
+      await initializeSlashCommands();
+      spinner.succeed('Slash commands created successfully!');
+      console.log(chalk.green('✅ Created .claude/commands directory'));
+      console.log(chalk.green('✅ Added /create-checkpoint command'));
+      console.log(chalk.green('✅ Added /restore-checkpoint command'));
+      console.log(chalk.green('✅ Added /list-checkpoints command'));
+      console.log(chalk.green('✅ Added /checkpoint-status command'));
+      
+      console.log(chalk.blue('\n🚀 Available slash commands in Claude Code:'));
+      console.log('  /create-checkpoint - Create a new checkpoint');
+      console.log('  /restore-checkpoint - Restore with interactive selection');
+      console.log('  /list-checkpoints - List all checkpoints');
+      console.log('  /checkpoint-status - Show current status');
+      
+      console.log(chalk.yellow('\n💡 Tip: Type / in Claude Code to see available commands!'));
+    } catch (error) {
+      spinner.fail('Failed to create slash commands');
+      console.error(chalk.red('Error:'), error.message);
       process.exit(1);
     }
   });

--- a/src/lib/slash-commands.js
+++ b/src/lib/slash-commands.js
@@ -1,0 +1,97 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+async function initializeSlashCommands(projectRoot = process.cwd()) {
+  const commandsDir = path.join(projectRoot, '.claude', 'commands');
+  
+  // Create commands directory
+  await fs.mkdir(commandsDir, { recursive: true });
+  
+  // Create /create-checkpoint command
+  const createCheckpointContent = `---
+description: Create a new checkpoint of your codebase
+argument-hint: [name] [description]
+---
+
+Use the ClaudePoint MCP tool to create a new checkpoint.
+
+If arguments are provided:
+- First argument: checkpoint name
+- Remaining arguments: description
+
+Example: /create-checkpoint auth-working Authentication system working perfectly
+
+Steps:
+1. Use the create_checkpoint tool from ClaudePoint
+2. Pass the name and description from $ARGUMENTS if provided
+3. Confirm the checkpoint was created successfully
+`;
+  
+  // Create /restore-checkpoint command
+  const restoreCheckpointContent = `---
+description: Restore a previous checkpoint with interactive selection
+---
+
+Help the user restore a checkpoint using ClaudePoint's restore_checkpoint tool.
+
+Steps:
+1. First, use the list_checkpoints tool to show all available checkpoints with numbering
+2. Ask the user: "Which checkpoint would you like to restore? Please provide the number or name."
+3. Wait for the user to respond with their selection
+4. Use the restore_checkpoint tool with the selected checkpoint name
+5. Confirm the restoration was successful
+
+Important: Always show the numbered list first and wait for user selection.
+`;
+  
+  // Create /list-checkpoints command
+  const listCheckpointsContent = `---
+description: List all available checkpoints
+---
+
+Use the ClaudePoint MCP tool list_checkpoints to show all available checkpoints.
+
+Display the results in a clear, organized format showing:
+- Checkpoint name
+- Description
+- Date created
+- Number of files
+- Size
+`;
+  
+  // Create /checkpoint-status command
+  const checkpointStatusContent = `---
+description: Show current checkpoint status and recent activity
+---
+
+Show the current status of checkpoints in this project using ClaudePoint tools.
+
+Steps:
+1. Use list_checkpoints to get total number of checkpoints and show the latest one
+2. Use get_changelog to show recent checkpoint activity
+3. Present a summary including:
+   - Total number of checkpoints
+   - Latest checkpoint details
+   - Recent checkpoint operations (last 5 entries)
+   
+Format the output clearly to give a quick overview of the checkpoint system status.
+`;
+  
+  // Write all command files
+  await fs.writeFile(path.join(commandsDir, 'create-checkpoint.md'), createCheckpointContent);
+  await fs.writeFile(path.join(commandsDir, 'restore-checkpoint.md'), restoreCheckpointContent);
+  await fs.writeFile(path.join(commandsDir, 'list-checkpoints.md'), listCheckpointsContent);
+  await fs.writeFile(path.join(commandsDir, 'checkpoint-status.md'), checkpointStatusContent);
+  
+  return {
+    success: true,
+    commandsCreated: [
+      'create-checkpoint',
+      'restore-checkpoint', 
+      'list-checkpoints',
+      'checkpoint-status'
+    ]
+  };
+}
+
+module.exports = { initializeSlashCommands };

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -14,13 +14,14 @@ const {
   ListToolsRequestSchema 
 } = require('@modelcontextprotocol/sdk/types.js');
 const CheckpointManager = require('./lib/checkpoint-manager.js');
+const { initializeSlashCommands } = require('./lib/slash-commands.js');
 
 class ClaudePointMCPServer {
   constructor() {
     this.server = new Server(
       {
         name: 'claudepoint',
-        version: '1.1.1',
+        version: '1.1.2',
       },
       {
         capabilities: {
@@ -120,6 +121,14 @@ class ClaudePointMCPServer {
               },
               required: ['description']
             }
+          },
+          {
+            name: 'init_slash_commands',
+            description: 'Initialize Claude Code slash commands for ClaudePoint (creates /create-checkpoint, /restore-checkpoint, /list-checkpoints, /checkpoint-status)',
+            inputSchema: {
+              type: 'object',
+              properties: {}
+            }
           }
         ]
       };
@@ -148,6 +157,9 @@ class ClaudePointMCPServer {
           
           case 'set_changelog':
             return await this.handleSetChangelog(args);
+          
+          case 'init_slash_commands':
+            return await this.handleInitSlashCommands(args);
           
           default:
             throw new Error(`Unknown tool: ${name}`);
@@ -428,6 +440,54 @@ class ClaudePointMCPServer {
     }
   }
 
+  async handleInitSlashCommands(args) {
+    try {
+      const result = await initializeSlashCommands();
+      
+      if (result.success) {
+        let output = '🚀 ClaudePoint slash commands initialized!\n\n';
+        output += '✅ Created .claude/commands directory\n';
+        output += '✅ Added /create-checkpoint command\n';
+        output += '✅ Added /restore-checkpoint command\n';
+        output += '✅ Added /list-checkpoints command\n';
+        output += '✅ Added /checkpoint-status command\n';
+        output += '\n💡 Available slash commands:\n';
+        output += '  • /create-checkpoint - Create a new checkpoint\n';
+        output += '  • /restore-checkpoint - Restore with interactive selection\n';
+        output += '  • /list-checkpoints - List all checkpoints\n';
+        output += '  • /checkpoint-status - Show current status\n';
+        output += '\n🎯 Type / in Claude Code to see and use these commands!';
+        
+        return {
+          content: [
+            {
+              type: 'text',
+              text: output
+            }
+          ]
+        };
+      } else {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `❌ Failed to initialize slash commands: ${result.error}`
+            }
+          ]
+        };
+      }
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `❌ Error initializing slash commands: ${error.message}`
+          }
+        ]
+      };
+    }
+  }
+
   async handleSetup(args) {
     try {
       const result = await this.manager.setup();
@@ -483,7 +543,7 @@ class ClaudePointMCPServer {
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
     console.error('ClaudePoint MCP server running on stdio');
-    console.error('Available tools: setup_claudepoint, create_checkpoint, list_checkpoints, restore_checkpoint, get_changelog, set_changelog');
+    console.error('Available tools: setup_claudepoint, create_checkpoint, list_checkpoints, restore_checkpoint, get_changelog, set_changelog, init_slash_commands');
   }
 }
 


### PR DESCRIPTION
## Summary
- Added automatic slash commands creation during ClaudePoint setup
- Created new `init-commands` CLI command for existing projects  
- Added `init_slash_commands` MCP tool for Claude to initialize commands via natural language

## Changes
- **Automatic slash commands**: Created automatically during every `claudepoint setup`
- **New CLI command**: `claudepoint init-commands` to add slash commands to existing projects
- **New MCP tool**: `init_slash_commands` allows Claude to create slash commands
- **Shared module**: Extracted command generation logic to `src/lib/slash-commands.js`
- **4 slash commands created**:
  - `/create-checkpoint` - Quick checkpoint creation with optional args
  - `/restore-checkpoint` - Interactive restoration with numbered list
  - `/list-checkpoints` - View all checkpoints  
  - `/checkpoint-status` - Show current status and recent activity

## Test Plan
- [ ] Run `claudepoint setup` and verify slash commands are created in `.claude/commands/`
- [ ] Run `claudepoint init-commands` on existing project
- [ ] Test `/create-checkpoint` command in Claude Code
- [ ] Test `/restore-checkpoint` with interactive selection
- [ ] Test `/list-checkpoints` command
- [ ] Test `/checkpoint-status` command
- [ ] Use `init_slash_commands` MCP tool from Claude

Closes #4